### PR TITLE
improve fetching of settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Mycroft user settings
+settings.json

--- a/__init__.py
+++ b/__init__.py
@@ -28,15 +28,30 @@ class SqueezeBoxMediaSkill(CommonPlaySkill):
         self.add_event("mycroft.audio.service.prev", self.handle_previoustrack)
         self.add_event("mycroft.audio.service.pause", self.handle_pause)
         self.add_event("mycroft.audio.service.resume", self.handle_resume)
-        if not self.settings:
-            raise ValueError("Could not load settings")
+
+        self.settings_change_callback = self.get_settings
+
+        self.sources_cache_filename = join(
+            abspath(dirname(__file__)), "sources_cache.json.gz"
+        )
+        self.library_cache_filename = join(
+            abspath(dirname(__file__)), "library_cache.json.gz"
+        )
+        self.library_total_duration_state_filename = join(
+            abspath(dirname(__file__)), "library_total_duration_state.json.gz"
+        )
+        self.scorer = QRatio
+        self.processor = full_process
+        self.regexes = {}
+
+    def get_settings(self):
         LOG.debug("Settings: {}".format(self.settings))
         try:
             self.lms = LMSClient(
-                self.settings["server"],
-                self.settings["port"],
-                self.settings["username"],
-                self.settings["password"],
+                self.settings.get("server"),
+                self.settings.get("port"),
+                self.settings.get("username"),
+                self.settings.get("password"),
             )
         except Exception as e:
             LOG.error(
@@ -44,7 +59,7 @@ class SqueezeBoxMediaSkill(CommonPlaySkill):
             )
             raise ValueError("Could not load server configuration.")
         try:
-            self.default_player_name = self.settings["default_player_name"]
+            self.default_player_name = self.settings.get("default_player_name")
         except Exception as e:
             LOG.error("Default player name not set. Exception: {}".format(e))
             raise ValueError("Default player name not set.")
@@ -63,18 +78,7 @@ class SqueezeBoxMediaSkill(CommonPlaySkill):
         self.podcast_source_enabled = self.settings.get(
             "podcast_source_enabled", True
         )
-        self.sources_cache_filename = join(
-            abspath(dirname(__file__)), "sources_cache.json.gz"
-        )
-        self.library_cache_filename = join(
-            abspath(dirname(__file__)), "library_cache.json.gz"
-        )
-        self.library_total_duration_state_filename = join(
-            abspath(dirname(__file__)), "library_total_duration_state.json.gz"
-        )
-        self.scorer = QRatio
-        self.processor = full_process
-        self.regexes = {}
+
         self.get_sources("connecting...")
 
     # Regex handler


### PR DESCRIPTION
Hi Johan, 

I saw some people having issues with getting the settings block to show up at Home.mycroft.ai so wanted to suggest a slight modification to how this is handled when the Skill is initialized. 

`self.settings_change_callback` defines a function to be called anytime the web settings are updated. So this PR separates all the settings fetching along with the call to `get_sources` to that callback. I also added `settings.json` to .gitignore so that no one accidentally commits their personal settings.

I don't have a Squeezebox server setup so haven't been able to test this end to end. It does however fix the settings fetching.

Thanks
Kris